### PR TITLE
Development job workflow 

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -170,19 +170,19 @@ workflows:
             - build-and-test
           filters:
             branches:
-              only: development
+              only: master
       - terraform-init-and-apply-to-development:
           requires:
             - assume-role-development
           filters:
             branches:
-              only: development
+              only: master
       - deploy-to-development:
           requires:
             - terraform-init-and-apply-to-development
           filters:
             branches:
-              only: development
+              only: master
   check-and-deploy-staging-and-production:
       jobs:
       - check-code-formatting


### PR DESCRIPTION
The development job workflow was still linked to `development `branch instead of `master `