### PR TITLE
Refactored pagination token implementation

### DIFF
--- a/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
+++ b/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
@@ -56,7 +56,7 @@ namespace NotesApi.Tests.V1.Controllers
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<NoteResponseObject>(5).ToList();
-            var pagedResult = new PagedResult<NoteResponseObject>(notes, paginationToken);
+            var pagedResult = new PagedResult<NoteResponseObject>(notes, new PaginationDetails(paginationToken));
             _mockGetByTargetIdUseCase.Setup(x => x.ExecuteAsync(query)).ReturnsAsync(pagedResult);
 
             // Act

--- a/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
+++ b/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
@@ -56,7 +56,7 @@ namespace NotesApi.Tests.V1.Controllers
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<NoteResponseObject>(5).ToList();
-            var pagedResult = new PagedResult<NoteResponseObject>(notes, new PaginationDetails(paginationToken));
+            var pagedResult = new PagedResult<NoteResponseObject>(notes, new PaginationDetails(paginationToken, null));
             _mockGetByTargetIdUseCase.Setup(x => x.ExecuteAsync(query)).ReturnsAsync(pagedResult);
 
             // Act

--- a/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
+++ b/NotesApi.Tests/V1/Controllers/NotesApiControllerTests.cs
@@ -56,7 +56,7 @@ namespace NotesApi.Tests.V1.Controllers
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<NoteResponseObject>(5).ToList();
-            var pagedResult = new PagedResult<NoteResponseObject>(notes, new PaginationDetails(paginationToken, null));
+            var pagedResult = new PagedResult<NoteResponseObject>(notes, new PaginationDetails(paginationToken));
             _mockGetByTargetIdUseCase.Setup(x => x.ExecuteAsync(query)).ReturnsAsync(pagedResult);
 
             // Act

--- a/NotesApi.Tests/V1/E2ETests/Steps/GetNotesSteps.cs
+++ b/NotesApi.Tests/V1/E2ETests/Steps/GetNotesSteps.cs
@@ -18,7 +18,8 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
         private readonly HttpClient _httpClient;
 
         private HttpResponseMessage _lastResponse;
-        private List<NoteResponseObject> _pagedNotes = new List<NoteResponseObject>();
+        private readonly List<NoteResponseObject> _pagedNotes = new List<NoteResponseObject>();
+        private static readonly JsonSerializerOptions _jsonOptions = CreateJsonOptions();
 
         public GetNotesSteps(HttpClient httpClient)
         {
@@ -60,7 +61,7 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
         {
             response.StatusCode.Should().Be(HttpStatusCode.OK);
             var responseContent = await response.Content.ReadAsStringAsync().ConfigureAwait(false);
-            var apiResult = JsonSerializer.Deserialize<PagedResult<NoteResponseObject>>(responseContent, CreateJsonOptions());
+            var apiResult = JsonSerializer.Deserialize<PagedResult<NoteResponseObject>>(responseContent, _jsonOptions);
             return apiResult;
         }
 
@@ -78,7 +79,7 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
                 var apiResult = await ExtractResultFromHttpResponse(response).ConfigureAwait(false);
                 _pagedNotes.AddRange(apiResult.Results);
 
-                pageToken = apiResult.PaginationToken;
+                pageToken = apiResult.PaginationDetails.MoreToken;
             }
             while (!string.IsNullOrEmpty(pageToken));
         }
@@ -93,7 +94,7 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
         public async Task ThenTheFirstPageOfTargetNotesAreReturned(List<NoteDb> expectedNotes)
         {
             var apiResult = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
-            apiResult.PaginationToken.Should().NotBeNullOrEmpty();
+            apiResult.PaginationDetails.MoreToken.Should().NotBeNullOrEmpty();
             apiResult.Results.Count.Should().Be(10);
             apiResult.Results.Should().BeEquivalentTo(expectedNotes.OrderByDescending(x => x.DateTime).Take(10));
 

--- a/NotesApi.Tests/V1/E2ETests/Steps/GetNotesSteps.cs
+++ b/NotesApi.Tests/V1/E2ETests/Steps/GetNotesSteps.cs
@@ -79,7 +79,7 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
                 var apiResult = await ExtractResultFromHttpResponse(response).ConfigureAwait(false);
                 _pagedNotes.AddRange(apiResult.Results);
 
-                pageToken = apiResult.PaginationDetails.MoreToken;
+                pageToken = apiResult.PaginationDetails.NextToken;
             }
             while (!string.IsNullOrEmpty(pageToken));
         }
@@ -94,7 +94,7 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
         public async Task ThenTheFirstPageOfTargetNotesAreReturned(List<NoteDb> expectedNotes)
         {
             var apiResult = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
-            apiResult.PaginationDetails.MoreToken.Should().NotBeNullOrEmpty();
+            apiResult.PaginationDetails.NextToken.Should().NotBeNullOrEmpty();
             apiResult.Results.Count.Should().Be(10);
             apiResult.Results.Should().BeEquivalentTo(expectedNotes.OrderByDescending(x => x.DateTime).Take(10));
 

--- a/NotesApi.Tests/V1/PagedResultTests.cs
+++ b/NotesApi.Tests/V1/PagedResultTests.cs
@@ -32,46 +32,12 @@ namespace NotesApi.Tests.V1
             sut.Results.Should().BeEquivalentTo(list);
         }
 
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("  ")]
-        [InlineData("{}")]
-        public void PagedResultConstructorSetEmptyPaginationToken(string token)
+        [Fact]
+        public void PagedResultConstructorSetPaginationToken()
         {
-            var sut = new PagedResult<string>(null, token);
-            sut.PaginationToken.Should().BeNull();
-        }
-
-        [Theory]
-        [InlineData("some value")]
-        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
-        public void PagedResultConstructorSetPaginationTokenValue(string token)
-        {
-            var sut = new PagedResult<string>(null, token);
-            sut.PaginationToken.Should().Be(token.Replace("\"", "'"));
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("  ")]
-        [InlineData("{}")]
-        public void PagedResultPaginationTokenSetsEmptyValue(string token)
-        {
-            var sut = new PagedResult<string>();
-            sut.PaginationToken = token;
-            sut.PaginationToken.Should().BeNull();
-        }
-
-        [Theory]
-        [InlineData("some value")]
-        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
-        public void PagedResultPaginationTokenSetsValue(string token)
-        {
-            var sut = new PagedResult<string>();
-            sut.PaginationToken = token;
-            sut.PaginationToken.Should().Be(token.Replace("\"", "'"));
+            var paginationDetails = new PaginationDetails();
+            var sut = new PagedResult<string>(null, paginationDetails);
+            sut.PaginationDetails.Should().Be(paginationDetails);
         }
     }
 }

--- a/NotesApi.Tests/V1/PaginationDetailsTests.cs
+++ b/NotesApi.Tests/V1/PaginationDetailsTests.cs
@@ -22,11 +22,9 @@ namespace NotesApi.Tests.V1
         [InlineData("{}")]
         public void CustomConstructorTestEmptyToken(string token)
         {
-            var sut = new PaginationDetails(token, token);
+            var sut = new PaginationDetails(token);
             sut.NextToken.Should().BeNull();
             sut.HasNext.Should().BeFalse();
-            sut.PreviousToken.Should().BeNull();
-            sut.HasPrevious.Should().BeFalse();
         }
 
         [Theory]
@@ -34,11 +32,9 @@ namespace NotesApi.Tests.V1
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
         public void CustomConstructorTestWithTokenValue(string token)
         {
-            var sut = new PaginationDetails(token, token);
+            var sut = new PaginationDetails(token);
             sut.NextToken.Should().Be(Base64UrlEncoder.Encode(token));
             sut.HasNext.Should().BeTrue();
-            sut.PreviousToken.Should().Be(Base64UrlEncoder.Encode(token));
-            sut.HasPrevious.Should().BeTrue();
         }
 
         [Theory]
@@ -57,30 +53,6 @@ namespace NotesApi.Tests.V1
         [Theory]
         [InlineData("some value")]
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
-        public void EncodePreviousTokenTestWithTokenValue(string token)
-        {
-            var sut = new PaginationDetails();
-            sut.EncodePreviousToken(token);
-            sut.PreviousToken.Should().Be(Base64UrlEncoder.Encode(token));
-            sut.HasPrevious.Should().BeTrue();
-        }
-
-        [Theory]
-        [InlineData(null)]
-        [InlineData("")]
-        [InlineData("  ")]
-        [InlineData("{}")]
-        public void EncodePreviousTokenTestEmptyToken(string token)
-        {
-            var sut = new PaginationDetails();
-            sut.EncodePreviousToken(token);
-            sut.PreviousToken.Should().BeNull();
-            sut.HasPrevious.Should().BeFalse();
-        }
-
-        [Theory]
-        [InlineData("some value")]
-        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
         public void EncodeNextTokenTestWithTokenValue(string token)
         {
             var sut = new PaginationDetails();
@@ -94,7 +66,6 @@ namespace NotesApi.Tests.V1
         {
             var sut = new PaginationDetails();
             sut.DecodeNextToken().Should().BeNull();
-            sut.DecodePreviousToken().Should().BeNull();
         }
 
         [Theory]
@@ -102,9 +73,8 @@ namespace NotesApi.Tests.V1
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
         public void DecodeTokensTestWithTokenValue(string token)
         {
-            var sut = new PaginationDetails(token, token);
+            var sut = new PaginationDetails(token);
             sut.DecodeNextToken().Should().Be(token);
-            sut.DecodePreviousToken().Should().Be(token);
         }
     }
 }

--- a/NotesApi.Tests/V1/PaginationDetailsTests.cs
+++ b/NotesApi.Tests/V1/PaginationDetailsTests.cs
@@ -1,0 +1,80 @@
+using FluentAssertions;
+using Microsoft.IdentityModel.Tokens;
+using NotesApi.V1;
+using Xunit;
+
+namespace NotesApi.Tests.V1
+{
+    public class PaginationDetailsTests
+    {
+        [Fact]
+        public void DefaultConstructorTest()
+        {
+            var sut = new PaginationDetails();
+            sut.MoreToken.Should().BeNull();
+            sut.HasMore.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("{}")]
+        public void CustomConstructorTestEmptyToken(string token)
+        {
+            var sut = new PaginationDetails(token);
+            sut.MoreToken.Should().BeNull();
+            sut.HasMore.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("some value")]
+        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
+        public void CustomConstructorTestWithTokenValue(string token)
+        {
+            var sut = new PaginationDetails(token);
+            sut.MoreToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasMore.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("{}")]
+        public void EncodeMoreTokenTestEmptyToken(string token)
+        {
+            var sut = new PaginationDetails();
+            sut.EncodeMoreToken(token);
+            sut.MoreToken.Should().BeNull();
+            sut.HasMore.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("some value")]
+        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
+        public void EncodeMoreTokenTestWithTokenValue(string token)
+        {
+            var sut = new PaginationDetails();
+            sut.EncodeMoreToken(token);
+            sut.MoreToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasMore.Should().BeTrue();
+        }
+
+        [Fact]
+        public void DecodeMoreTokenTestEmptyToken()
+        {
+            var sut = new PaginationDetails();
+            sut.DecodeMoreToken().Should().BeNull();
+        }
+
+        [Theory]
+        [InlineData("some value")]
+        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
+        public void DecodeMoreTokenTestWithTokenValue(string token)
+        {
+            var sut = new PaginationDetails(token);
+            sut.DecodeMoreToken().Should().Be(token);
+        }
+    }
+}

--- a/NotesApi.Tests/V1/PaginationDetailsTests.cs
+++ b/NotesApi.Tests/V1/PaginationDetailsTests.cs
@@ -11,8 +11,8 @@ namespace NotesApi.Tests.V1
         public void DefaultConstructorTest()
         {
             var sut = new PaginationDetails();
-            sut.MoreToken.Should().BeNull();
-            sut.HasMore.Should().BeFalse();
+            sut.NextToken.Should().BeNull();
+            sut.HasNext.Should().BeFalse();
         }
 
         [Theory]
@@ -22,9 +22,11 @@ namespace NotesApi.Tests.V1
         [InlineData("{}")]
         public void CustomConstructorTestEmptyToken(string token)
         {
-            var sut = new PaginationDetails(token);
-            sut.MoreToken.Should().BeNull();
-            sut.HasMore.Should().BeFalse();
+            var sut = new PaginationDetails(token, token);
+            sut.NextToken.Should().BeNull();
+            sut.HasNext.Should().BeFalse();
+            sut.PreviousToken.Should().BeNull();
+            sut.HasPrevious.Should().BeFalse();
         }
 
         [Theory]
@@ -32,9 +34,11 @@ namespace NotesApi.Tests.V1
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
         public void CustomConstructorTestWithTokenValue(string token)
         {
-            var sut = new PaginationDetails(token);
-            sut.MoreToken.Should().Be(Base64UrlEncoder.Encode(token));
-            sut.HasMore.Should().BeTrue();
+            var sut = new PaginationDetails(token, token);
+            sut.NextToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasNext.Should().BeTrue();
+            sut.PreviousToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasPrevious.Should().BeTrue();
         }
 
         [Theory]
@@ -42,39 +46,65 @@ namespace NotesApi.Tests.V1
         [InlineData("")]
         [InlineData("  ")]
         [InlineData("{}")]
-        public void EncodeMoreTokenTestEmptyToken(string token)
+        public void EncodeNextTokenTestEmptyToken(string token)
         {
             var sut = new PaginationDetails();
-            sut.EncodeMoreToken(token);
-            sut.MoreToken.Should().BeNull();
-            sut.HasMore.Should().BeFalse();
+            sut.EncodeNextToken(token);
+            sut.NextToken.Should().BeNull();
+            sut.HasNext.Should().BeFalse();
         }
 
         [Theory]
         [InlineData("some value")]
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
-        public void EncodeMoreTokenTestWithTokenValue(string token)
+        public void EncodePreviousTokenTestWithTokenValue(string token)
         {
             var sut = new PaginationDetails();
-            sut.EncodeMoreToken(token);
-            sut.MoreToken.Should().Be(Base64UrlEncoder.Encode(token));
-            sut.HasMore.Should().BeTrue();
+            sut.EncodePreviousToken(token);
+            sut.PreviousToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasPrevious.Should().BeTrue();
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        [InlineData("  ")]
+        [InlineData("{}")]
+        public void EncodePreviousTokenTestEmptyToken(string token)
+        {
+            var sut = new PaginationDetails();
+            sut.EncodePreviousToken(token);
+            sut.PreviousToken.Should().BeNull();
+            sut.HasPrevious.Should().BeFalse();
+        }
+
+        [Theory]
+        [InlineData("some value")]
+        [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
+        public void EncodeNextTokenTestWithTokenValue(string token)
+        {
+            var sut = new PaginationDetails();
+            sut.EncodeNextToken(token);
+            sut.NextToken.Should().Be(Base64UrlEncoder.Encode(token));
+            sut.HasNext.Should().BeTrue();
         }
 
         [Fact]
-        public void DecodeMoreTokenTestEmptyToken()
+        public void DecodeTokensTestEmptyToken()
         {
             var sut = new PaginationDetails();
-            sut.DecodeMoreToken().Should().BeNull();
+            sut.DecodeNextToken().Should().BeNull();
+            sut.DecodePreviousToken().Should().BeNull();
         }
 
         [Theory]
         [InlineData("some value")]
         [InlineData("{ \"id\": \"123\", \"name\": \"some name\"  }")]
-        public void DecodeMoreTokenTestWithTokenValue(string token)
+        public void DecodeTokensTestWithTokenValue(string token)
         {
-            var sut = new PaginationDetails(token);
-            sut.DecodeMoreToken().Should().Be(token);
+            var sut = new PaginationDetails(token, token);
+            sut.DecodeNextToken().Should().Be(token);
+            sut.DecodePreviousToken().Should().Be(token);
         }
     }
 }

--- a/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
+++ b/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
@@ -37,7 +37,7 @@ namespace NotesApi.Tests.V1.UseCase
             // Arrange
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
-            var gatewayResult = new PagedResult<Note>(null, new PaginationDetails(paginationToken));
+            var gatewayResult = new PagedResult<Note>(null, new PaginationDetails(paginationToken, null));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -76,7 +76,7 @@ namespace NotesApi.Tests.V1.UseCase
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<Note>(5).ToList();
-            var gatewayResult = new PagedResult<Note>(notes, new PaginationDetails(paginationToken));
+            var gatewayResult = new PagedResult<Note>(notes, new PaginationDetails(paginationToken, null));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -85,9 +85,9 @@ namespace NotesApi.Tests.V1.UseCase
             // Assert
             response.Results.Should().BeEquivalentTo(notes.ToResponse());
             if (string.IsNullOrEmpty(paginationToken))
-                response.PaginationDetails.MoreToken.Should().BeNull();
+                response.PaginationDetails.NextToken.Should().BeNull();
             else
-                response.PaginationDetails.DecodeMoreToken().Should().Be(paginationToken);
+                response.PaginationDetails.DecodeNextToken().Should().Be(paginationToken);
         }
 
         [Theory]

--- a/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
+++ b/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
@@ -37,7 +37,7 @@ namespace NotesApi.Tests.V1.UseCase
             // Arrange
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
-            var gatewayResult = new PagedResult<Note>(null, new PaginationDetails(paginationToken, null));
+            var gatewayResult = new PagedResult<Note>(null, new PaginationDetails(paginationToken));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -76,7 +76,7 @@ namespace NotesApi.Tests.V1.UseCase
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<Note>(5).ToList();
-            var gatewayResult = new PagedResult<Note>(notes, new PaginationDetails(paginationToken, null));
+            var gatewayResult = new PagedResult<Note>(notes, new PaginationDetails(paginationToken));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act

--- a/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
+++ b/NotesApi.Tests/V1/UseCase/GetByTargetIdUseCaseTests.cs
@@ -37,7 +37,7 @@ namespace NotesApi.Tests.V1.UseCase
             // Arrange
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
-            var gatewayResult = new PagedResult<Note>(null, paginationToken);
+            var gatewayResult = new PagedResult<Note>(null, new PaginationDetails(paginationToken));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -56,7 +56,7 @@ namespace NotesApi.Tests.V1.UseCase
             // Arrange
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
-            var gatewayResult = new PagedResult<Note>(new List<Note>(), null);
+            var gatewayResult = new PagedResult<Note>(new List<Note>());
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -76,7 +76,7 @@ namespace NotesApi.Tests.V1.UseCase
             var id = Guid.NewGuid();
             var query = new GetNotesByTargetIdQuery { TargetId = id, PaginationToken = paginationToken };
             var notes = _fixture.CreateMany<Note>(5).ToList();
-            var gatewayResult = new PagedResult<Note>(notes, paginationToken);
+            var gatewayResult = new PagedResult<Note>(notes, new PaginationDetails(paginationToken));
             _mockGateway.Setup(x => x.GetByTargetIdAsync(query)).ReturnsAsync(gatewayResult);
 
             // Act
@@ -85,9 +85,9 @@ namespace NotesApi.Tests.V1.UseCase
             // Assert
             response.Results.Should().BeEquivalentTo(notes.ToResponse());
             if (string.IsNullOrEmpty(paginationToken))
-                response.PaginationToken.Should().BeNull();
+                response.PaginationDetails.MoreToken.Should().BeNull();
             else
-                response.PaginationToken.Should().Be(paginationToken);
+                response.PaginationDetails.DecodeMoreToken().Should().Be(paginationToken);
         }
 
         [Theory]

--- a/NotesApi/NotesApi.csproj
+++ b/NotesApi/NotesApi.csproj
@@ -23,6 +23,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning" Version="4.1.1" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Versioning.ApiExplorer" Version="4.1.1" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="3.0.0" />
+    <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="6.10.2" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Swagger" Version="5.4.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="5.4.1" />

--- a/NotesApi/V1/Gateways/NotesDbGateway.cs
+++ b/NotesApi/V1/Gateways/NotesDbGateway.cs
@@ -38,14 +38,14 @@ namespace NotesApi.V1.Gateways
                 BackwardSearch = true,
                 ConsistentRead = true,
                 Limit = MAX_RESULTS,
-                PaginationToken = query.PaginationToken,
+                PaginationToken = PaginationDetails.DecodeToken(query.PaginationToken),
                 Filter = new QueryFilter(TARGETID, QueryOperator.Equal, query.TargetId)
             });
             var resultsSet = await search.GetNextSetAsync().ConfigureAwait(false);
             if (resultsSet.Any())
                 dbNotes.AddRange(_dynamoDbContext.FromDocuments<NoteDb>(resultsSet));
 
-            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()), search.PaginationToken);
+            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()), new PaginationDetails(search.PaginationToken));
         }
     }
 }

--- a/NotesApi/V1/Gateways/NotesDbGateway.cs
+++ b/NotesApi/V1/Gateways/NotesDbGateway.cs
@@ -45,8 +45,7 @@ namespace NotesApi.V1.Gateways
             if (resultsSet.Any())
                 dbNotes.AddRange(_dynamoDbContext.FromDocuments<NoteDb>(resultsSet));
 
-            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()),
-                                         new PaginationDetails(search.PaginationToken, query.PaginationToken));
+            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()), new PaginationDetails(search.PaginationToken));
         }
     }
 }

--- a/NotesApi/V1/Gateways/NotesDbGateway.cs
+++ b/NotesApi/V1/Gateways/NotesDbGateway.cs
@@ -45,7 +45,8 @@ namespace NotesApi.V1.Gateways
             if (resultsSet.Any())
                 dbNotes.AddRange(_dynamoDbContext.FromDocuments<NoteDb>(resultsSet));
 
-            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()), new PaginationDetails(search.PaginationToken));
+            return new PagedResult<Note>(dbNotes.Select(x => x.ToDomain()),
+                                         new PaginationDetails(search.PaginationToken, query.PaginationToken));
         }
     }
 }

--- a/NotesApi/V1/PagedResult.cs
+++ b/NotesApi/V1/PagedResult.cs
@@ -6,28 +6,17 @@ namespace NotesApi.V1
     {
         public List<T> Results { get; set; } = new List<T>();
 
-        private string _paginationToken;
-        public string PaginationToken
-        {
-            get { return _paginationToken; }
-            set { _paginationToken = ValidatePaginationToken(value); }
-        }
+        public PaginationDetails PaginationDetails { get; set; } = new PaginationDetails();
 
         public PagedResult() { }
-        public PagedResult(IEnumerable<T> results, string paginationToken)
+        public PagedResult(IEnumerable<T> results)
         {
             if (null != results) Results.AddRange(results);
-            PaginationToken = paginationToken;
         }
-
-        private static string ValidatePaginationToken(string paginationToken)
+        public PagedResult(IEnumerable<T> results, PaginationDetails paginationDetails)
         {
-            // The AWS SDK can either return an empty JSON object (i.e. '{}') when there are no more results.
-            if (string.IsNullOrWhiteSpace(paginationToken?.Trim(' ', '{', '}')))
-                return null;
-
-            // Or a JSON object with escaped double quotes (i.e. '\"')
-            return paginationToken.Replace("\"", "'");
+            if (null != results) Results.AddRange(results);
+            PaginationDetails = paginationDetails;
         }
     }
 }

--- a/NotesApi/V1/PaginationDetails.cs
+++ b/NotesApi/V1/PaginationDetails.cs
@@ -6,13 +6,18 @@ namespace NotesApi.V1
     public class PaginationDetails
     {
         [JsonIgnore]
-        public bool HasMore => !string.IsNullOrEmpty(MoreToken);
-        public string MoreToken { get; set; }
+        public bool HasNext => !string.IsNullOrEmpty(NextToken);
+        public string NextToken { get; set; }
+
+        [JsonIgnore]
+        public bool HasPrevious => !string.IsNullOrEmpty(PreviousToken);
+        public string PreviousToken { get; set; }
 
         public PaginationDetails() { }
-        public PaginationDetails(string rawMoreToken)
+        public PaginationDetails(string rawNextToken, string rawPreviousToken)
         {
-            EncodeMoreToken(rawMoreToken);
+            EncodeNextToken(rawNextToken);
+            EncodePreviousToken(rawPreviousToken);
         }
 
         public static string EncodeToken(string rawToken)
@@ -32,14 +37,24 @@ namespace NotesApi.V1
             return Base64UrlEncoder.Decode(token);
         }
 
-        public void EncodeMoreToken(string rawToken)
+        public void EncodeNextToken(string rawToken)
         {
-            MoreToken = EncodeToken(rawToken);
+            NextToken = EncodeToken(rawToken);
         }
 
-        public string DecodeMoreToken()
+        public string DecodeNextToken()
         {
-            return DecodeToken(MoreToken);
+            return DecodeToken(NextToken);
+        }
+
+        public void EncodePreviousToken(string rawToken)
+        {
+            PreviousToken = EncodeToken(rawToken);
+        }
+
+        public string DecodePreviousToken()
+        {
+            return DecodeToken(PreviousToken);
         }
     }
 }

--- a/NotesApi/V1/PaginationDetails.cs
+++ b/NotesApi/V1/PaginationDetails.cs
@@ -9,15 +9,10 @@ namespace NotesApi.V1
         public bool HasNext => !string.IsNullOrEmpty(NextToken);
         public string NextToken { get; set; }
 
-        [JsonIgnore]
-        public bool HasPrevious => !string.IsNullOrEmpty(PreviousToken);
-        public string PreviousToken { get; set; }
-
         public PaginationDetails() { }
-        public PaginationDetails(string rawNextToken, string rawPreviousToken)
+        public PaginationDetails(string rawNextToken)
         {
             EncodeNextToken(rawNextToken);
-            EncodePreviousToken(rawPreviousToken);
         }
 
         public static string EncodeToken(string rawToken)
@@ -45,16 +40,6 @@ namespace NotesApi.V1
         public string DecodeNextToken()
         {
             return DecodeToken(NextToken);
-        }
-
-        public void EncodePreviousToken(string rawToken)
-        {
-            PreviousToken = EncodeToken(rawToken);
-        }
-
-        public string DecodePreviousToken()
-        {
-            return DecodeToken(PreviousToken);
         }
     }
 }

--- a/NotesApi/V1/PaginationDetails.cs
+++ b/NotesApi/V1/PaginationDetails.cs
@@ -1,0 +1,45 @@
+using Microsoft.IdentityModel.Tokens;
+using System.Text.Json.Serialization;
+
+namespace NotesApi.V1
+{
+    public class PaginationDetails
+    {
+        [JsonIgnore]
+        public bool HasMore => !string.IsNullOrEmpty(MoreToken);
+        public string MoreToken { get; set; }
+
+        public PaginationDetails() { }
+        public PaginationDetails(string rawMoreToken)
+        {
+            EncodeMoreToken(rawMoreToken);
+        }
+
+        public static string EncodeToken(string rawToken)
+        {
+            // The AWS SDK can either return an empty JSON object (i.e. '{}') when there are no more results.
+            if (string.IsNullOrWhiteSpace(rawToken?.Trim(' ', '{', '}')))
+                return null;
+
+            return Base64UrlEncoder.Encode(rawToken);
+        }
+
+        public static string DecodeToken(string token)
+        {
+            if (string.IsNullOrWhiteSpace(token))
+                return null;
+
+            return Base64UrlEncoder.Decode(token);
+        }
+
+        public void EncodeMoreToken(string rawToken)
+        {
+            MoreToken = EncodeToken(rawToken);
+        }
+
+        public string DecodeMoreToken()
+        {
+            return DecodeToken(MoreToken);
+        }
+    }
+}

--- a/NotesApi/V1/UseCase/GetByTargetIdUseCase.cs
+++ b/NotesApi/V1/UseCase/GetByTargetIdUseCase.cs
@@ -3,8 +3,6 @@ using NotesApi.V1.Domain.Queries;
 using NotesApi.V1.Factories;
 using NotesApi.V1.Gateways;
 using NotesApi.V1.UseCase.Interfaces;
-using System;
-using System.Collections.Generic;
 using System.Threading.Tasks;
 
 namespace NotesApi.V1.UseCase
@@ -21,7 +19,7 @@ namespace NotesApi.V1.UseCase
         public async Task<PagedResult<NoteResponseObject>> ExecuteAsync(GetNotesByTargetIdQuery query)
         {
             var gatewayResult = await _gateway.GetByTargetIdAsync(query).ConfigureAwait(false);
-            return new PagedResult<NoteResponseObject>(gatewayResult.Results.ToResponse(), gatewayResult.PaginationToken);
+            return new PagedResult<NoteResponseObject>(gatewayResult.Results.ToResponse(), gatewayResult.PaginationDetails);
         }
     }
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-506

## Describe this PR

Refactor the implementation and use of the pagination token for get notes. 

### *What changes have we introduced*

The previous implementation simply included the pagination token provided by DynamoDb back to the client.
This has the following drawbacks:
* It un-necessarily gives details of the data model and database implementation to the client.
* The database token is actually a json object meaning that for a client to include it in a subsequent call, then it will need to be fully escaped so that it will pass through Cloudfront.

The new implementation now...
* Encodes the token provided by DynamoDb as a Base64 string. This means that the client does not need to modify it in anyway before including it in any subsequent call.
* Wraps the token to get more data in a new object, which could be extended in future to include a backwards token.
    * See https://hackernoon.com/guys-were-doing-pagination-wrong-f6c18a91b232.

### *Follow up actions after merging PR*

Update the Swagger hub documentation to reflect the new response payload format.