### PR TITLE
Get notes page size can now be supplied by the caller

### DIFF
--- a/NotesApi.Tests/V1/E2ETests/Stories/GetNotesByTargetIdTests.cs
+++ b/NotesApi.Tests/V1/E2ETests/Stories/GetNotesByTargetIdTests.cs
@@ -53,6 +53,20 @@ namespace NotesApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
 
+        [Theory]
+        [InlineData(null)]
+        [InlineData(5)]
+        [InlineData(15)]
+        [InlineData(100)]
+        [SuppressMessage("Blocker Code Smell", "S2699:Tests should include assertions", Justification = "BDDfy")]
+        public void ServiceReturnsTheRequestedNotesByPageSize(int? pageSize)
+        {
+            this.Given(g => _notesFixture.GivenTargetNotesAlreadyExist(30))
+                .When(w => _steps.WhenTheTargetNotesAreRequestedWithPageSize(_notesFixture.TargetId.ToString(), pageSize))
+                .Then(t => _steps.ThenTheTargetNotesAreReturnedByPageSize(_notesFixture.Notes, pageSize))
+                .BDDfy();
+        }
+
         [Fact]
         [SuppressMessage("Blocker Code Smell", "S2699:Tests should include assertions", Justification = "BDDfy")]
         public void ServiceReturnsFirstPageOfRequestedNotesWithPaginationToken()

--- a/NotesApi/V1/Domain/Queries/GetNotesByTargetIdQuery.cs
+++ b/NotesApi/V1/Domain/Queries/GetNotesByTargetIdQuery.cs
@@ -12,5 +12,8 @@ namespace NotesApi.V1.Domain.Queries
 
         [FromQuery]
         public string PaginationToken { get; set; }
+
+        [FromQuery]
+        public int? PageSize { get; set; }
     }
 }

--- a/NotesApi/V1/Gateways/NotesDbGateway.cs
+++ b/NotesApi/V1/Gateways/NotesDbGateway.cs
@@ -30,6 +30,7 @@ namespace NotesApi.V1.Gateways
         [ExcludeFromCodeCoverage]
         public async Task<PagedResult<Note>> GetByTargetIdAsync(GetNotesByTargetIdQuery query)
         {
+            int pageSize = query.PageSize.HasValue ? query.PageSize.Value : MAX_RESULTS;
             var dbNotes = new List<NoteDb>();
             var table = _dynamoDbContext.GetTargetTable<NoteDb>();
             var search = table.Query(new QueryOperationConfig
@@ -37,7 +38,7 @@ namespace NotesApi.V1.Gateways
                 IndexName = GETNOTESBYTARGETIDINDEX,
                 BackwardSearch = true,
                 ConsistentRead = true,
-                Limit = MAX_RESULTS,
+                Limit = pageSize,
                 PaginationToken = PaginationDetails.DecodeToken(query.PaginationToken),
                 Filter = new QueryFilter(TARGETID, QueryOperator.Equal, query.TargetId)
             });


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-506
## Describe this PR

The Get Notes page size can now optionally be supplied on the query string.
If not provided then the default stays at 10.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

Update the Swagger hub documentation to reflect the new query format.