### PR TITLE
Return error codes for certain validation errors

### DIFF
--- a/NotesApi.Tests/NotesApi.Tests.csproj
+++ b/NotesApi.Tests/NotesApi.Tests.csproj
@@ -41,8 +41,4 @@
     <ProjectReference Include="..\NotesApi\NotesApi.csproj" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="V1\Infrastructure\" />
-  </ItemGroup>
-
 </Project>

--- a/NotesApi.Tests/V1/Boundary/Request/Validation/AuthorDetailsValidatorTests.cs
+++ b/NotesApi.Tests/V1/Boundary/Request/Validation/AuthorDetailsValidatorTests.cs
@@ -14,23 +14,54 @@ namespace NotesApi.Tests.V1.Boundary.Request.Validation
             _sut = new AuthorDetailsValidator();
         }
 
+        private const string ValueWithTags = "sdfsdf<sometag>@abc.com";
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void AuthorDetailsShouldErrorWithNoEmailValue(string value)
+        {
+            var model = new AuthorDetails() { Email = value };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.Email);
+        }
+
         [Theory]
         [InlineData("sdfsdf")]
-        [InlineData("sdfsdf<sometag>")]
         public void AuthorDetailsShouldErrorWithInvalidEmail(string invalidEmail)
         {
             var model = new AuthorDetails() { Email = invalidEmail };
             var result = _sut.TestValidate(model);
-            result.ShouldHaveValidationErrorFor(x => x.Email);
+            result.ShouldHaveValidationErrorFor(x => x.Email)
+                .WithErrorCode(ErrorCodes.InvalidEmail);
+        }
+
+        [Fact]
+        public void AuthorDetailsShouldErrorWithTagsInEmail()
+        {
+            var model = new AuthorDetails() { Email = ValueWithTags };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.Email)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
         }
 
         [Theory]
-        [InlineData("sdfsdf<sometag>")]
-        public void AuthorDetailsShouldErrorWithInvalidName(string invalidName)
+        [InlineData(null)]
+        [InlineData("")]
+        public void AuthorDetailsShouldErrorWithNoNameValue(string value)
         {
-            var model = new AuthorDetails() { FullName = invalidName };
+            var model = new AuthorDetails() { FullName = value };
             var result = _sut.TestValidate(model);
-            result.ShouldHaveValidationErrorFor(x => x.FullName);
+            result.ShouldNotHaveValidationErrorFor(x => x.FullName);
+        }
+
+        [Fact]
+        public void AuthorDetailsShouldErrorWithTagsInName()
+        {
+            var model = new AuthorDetails() { FullName = ValueWithTags };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.FullName)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
         }
     }
 }

--- a/NotesApi.Tests/V1/Boundary/Request/Validation/CategorisationValidatorTests.cs
+++ b/NotesApi.Tests/V1/Boundary/Request/Validation/CategorisationValidatorTests.cs
@@ -1,0 +1,76 @@
+using FluentValidation.TestHelper;
+using NotesApi.V1.Boundary.Request.Validation;
+using NotesApi.V1.Domain;
+using Xunit;
+
+namespace NotesApi.Tests.V1.Boundary.Request.Validation
+{
+    public class CategorisationValidatorTests
+    {
+        private readonly CategorisationValidator _sut;
+
+        public CategorisationValidatorTests()
+        {
+            _sut = new CategorisationValidator();
+        }
+
+        private const string StringWithTags = "Some string with <tag> in it.";
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CategorisationShouldErrorWithNoCategoryValue(string value)
+        {
+            var model = new Categorisation() { Category = value };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.Category);
+        }
+
+        [Fact]
+        public void CategorisationShouldErrorWithTagsInCategory()
+        {
+            var model = new Categorisation() { Category = StringWithTags };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.Category)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CategorisationShouldErrorWithNoSubCategoryValue(string value)
+        {
+            var model = new Categorisation() { SubCategory = value };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.SubCategory);
+        }
+
+        [Fact]
+        public void CategorisationShouldErrorWithTagsInSubCategory()
+        {
+            var model = new Categorisation() { SubCategory = StringWithTags };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.SubCategory)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void CategorisationShouldErrorWithNoDescriptionValue(string value)
+        {
+            var model = new Categorisation() { Description = value };
+            var result = _sut.TestValidate(model);
+            result.ShouldNotHaveValidationErrorFor(x => x.Description);
+        }
+
+        [Fact]
+        public void CategorisationShouldErrorWithTagsInDescription()
+        {
+            var model = new Categorisation() { Description = StringWithTags };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.Description)
+                .WithErrorCode(ErrorCodes.XssCheckFailure);
+        }
+    }
+}

--- a/NotesApi.Tests/V1/Boundary/Request/Validation/CreateNoteRequestValidatorTests.cs
+++ b/NotesApi.Tests/V1/Boundary/Request/Validation/CreateNoteRequestValidatorTests.cs
@@ -24,7 +24,8 @@ namespace NotesApi.Tests.V1.Boundary.Request.Validation
         {
             var model = new CreateNoteRequest() { Description = description };
             var result = _sut.TestValidate(model);
-            result.ShouldHaveValidationErrorFor(x => x.Description);
+            result.ShouldHaveValidationErrorFor(x => x.Description)
+                  .WithErrorCode("W2");
         }
 
         [Fact]
@@ -36,7 +37,18 @@ namespace NotesApi.Tests.V1.Boundary.Request.Validation
                 description += msgToRepeat;
             var model = new CreateNoteRequest() { Description = description };
             var result = _sut.TestValidate(model);
-            result.ShouldHaveValidationErrorFor(x => x.Description);
+            result.ShouldHaveValidationErrorFor(x => x.Description)
+                  .WithErrorCode("W3");
+        }
+
+        [Fact(Skip = "List of special characters still under discussion...")]
+        public void RequestShouldErrorWithSpecialCharacters()
+        {
+            string description = "This description is not ^ fine as it # has special ~ characters.";
+            var model = new CreateNoteRequest() { Description = description };
+            var result = _sut.TestValidate(model);
+            result.ShouldHaveValidationErrorFor(x => x.Description)
+                  .WithErrorCode("W8");
         }
 
         [Fact]

--- a/NotesApi.Tests/V1/E2ETests/Fixtures/NotesFixture.cs
+++ b/NotesApi.Tests/V1/E2ETests/Fixtures/NotesFixture.cs
@@ -54,12 +54,14 @@ namespace NotesApi.Tests.V1.E2ETests.Fixtures
             }
         }
 
-        private static CreateNoteRequest CreateNote()
+        private CreateNoteRequest CreateNote()
         {
-            var note = new Fixture().Create<CreateNoteRequest>();
+            var note = _fixture.Build<CreateNoteRequest>()
+                               .With(x => x.TargetId, Guid.NewGuid())
+                               .With(x => x.CreatedAt, DateTime.UtcNow)
+                               .With(x => x.Description, "Some valid note description.")
+                               .Create();
 
-            note.TargetId = Guid.NewGuid();
-            note.CreatedAt = DateTime.Now;
             note.Author.Email = "something@somewhere.com";
             return note;
         }
@@ -109,6 +111,12 @@ namespace NotesApi.Tests.V1.E2ETests.Fixtures
         public void GivenAnInvalidNewNotePayload()
         {
             InvalidPayload = "This is invalid json";
+        }
+
+        public void GivenANewNotePayloadWithDescription(string desc)
+        {
+            NoteRequest = CreateNote();
+            NoteRequest.Description = desc;
         }
 
         public void GivenANewNotePayloadWithTooLongDescription()

--- a/NotesApi.Tests/V1/E2ETests/Steps/PostNoteSteps.cs
+++ b/NotesApi.Tests/V1/E2ETests/Steps/PostNoteSteps.cs
@@ -107,14 +107,21 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
 
         public async Task ThenBadRequestValidationErrorResultIsReturned(string propertyName)
         {
-            await ThenBadRequestValidationErrorResultIsReturned(propertyName, null).ConfigureAwait(false);
+            await ThenBadRequestValidationErrorResultIsReturned(propertyName, null, null).ConfigureAwait(false);
         }
-        public async Task ThenBadRequestValidationErrorResultIsReturned(string propertyName, string errorMsg)
+
+        public async Task ThenBadRequestValidationErrorResultIsReturned(string propertyName, string errorCode)
+        {
+            await ThenBadRequestValidationErrorResultIsReturned(propertyName, errorCode, null).ConfigureAwait(false);
+        }
+        public async Task ThenBadRequestValidationErrorResultIsReturned(string propertyName, string errorCode, string errorMsg)
         {
             _lastResponse.StatusCode.Should().Be(HttpStatusCode.BadRequest);
             var resultBody = await _lastResponse.Content.ReadAsStringAsync().ConfigureAwait(false);
             resultBody.Should().Contain("One or more validation errors occurred");
             resultBody.Should().Contain(propertyName);
+            if (null != errorCode)
+                resultBody.Should().Contain(errorCode);
             if (null != errorMsg)
                 resultBody.Should().Contain(errorMsg);
         }

--- a/NotesApi.Tests/V1/E2ETests/Stories/PostNewNoteTests.cs
+++ b/NotesApi.Tests/V1/E2ETests/Stories/PostNewNoteTests.cs
@@ -61,12 +61,23 @@ namespace NotesApi.Tests.V1.E2ETests.Stories
                 .BDDfy();
         }
 
-        [Fact]
-        public void PostingANoteTestNoDescriptionReturns400()
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void PostingANoteTestNoDescriptionReturns400(string desc)
         {
-            this.Given(g => _notesFixture.GivenANewNotePayloadWithTooLongDescription())
+            this.Given(g => _notesFixture.GivenANewNotePayloadWithDescription(desc))
                 .When(w => _steps.WhenPostingANote(_notesFixture))
-                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description"))
+                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W2"))
+                .BDDfy();
+        }
+
+        [Fact(Skip = "List of special characters still under discussion...")]
+        public void PostingANoteTestDescriptionWithSpecialCharactersReturns400()
+        {
+            this.Given(g => _notesFixture.GivenANewNotePayloadWithDescription("Some description with ~`^ characters"))
+                .When(w => _steps.WhenPostingANote(_notesFixture))
+                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W8"))
                 .BDDfy();
         }
 
@@ -75,7 +86,7 @@ namespace NotesApi.Tests.V1.E2ETests.Stories
         {
             this.Given(g => _notesFixture.GivenANewNotePayloadWithTooLongDescription())
                 .When(w => _steps.WhenPostingANote(_notesFixture))
-                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description",
+                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W3",
                                     "'Description' must be between 1 and 500 characters."))
                 .BDDfy();
         }

--- a/NotesApi.Tests/V1/E2ETests/Stories/PostNewNoteTests.cs
+++ b/NotesApi.Tests/V1/E2ETests/Stories/PostNewNoteTests.cs
@@ -1,5 +1,6 @@
 using NotesApi.Tests.V1.E2ETests.Fixtures;
 using NotesApi.Tests.V1.E2ETests.Steps;
+using NotesApi.V1.Boundary.Request.Validation;
 using System;
 using TestStack.BDDfy;
 using Xunit;
@@ -68,16 +69,7 @@ namespace NotesApi.Tests.V1.E2ETests.Stories
         {
             this.Given(g => _notesFixture.GivenANewNotePayloadWithDescription(desc))
                 .When(w => _steps.WhenPostingANote(_notesFixture))
-                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W2"))
-                .BDDfy();
-        }
-
-        [Fact(Skip = "List of special characters still under discussion...")]
-        public void PostingANoteTestDescriptionWithSpecialCharactersReturns400()
-        {
-            this.Given(g => _notesFixture.GivenANewNotePayloadWithDescription("Some description with ~`^ characters"))
-                .When(w => _steps.WhenPostingANote(_notesFixture))
-                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W8"))
+                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", ErrorCodes.DescriptionMandatory))
                 .BDDfy();
         }
 
@@ -86,7 +78,7 @@ namespace NotesApi.Tests.V1.E2ETests.Stories
         {
             this.Given(g => _notesFixture.GivenANewNotePayloadWithTooLongDescription())
                 .When(w => _steps.WhenPostingANote(_notesFixture))
-                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", "W3",
+                .Then(t => _steps.ThenBadRequestValidationErrorResultIsReturned("Description", ErrorCodes.DescriptionTooLong,
                                     "'Description' must be between 1 and 500 characters."))
                 .BDDfy();
         }

--- a/NotesApi.Tests/V1/Infrastructure/FluentValidationExtensionsTests.cs
+++ b/NotesApi.Tests/V1/Infrastructure/FluentValidationExtensionsTests.cs
@@ -1,0 +1,103 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using Microsoft.Extensions.DependencyInjection;
+using NotesApi.V1.Infrastructure;
+using System;
+using System.Linq;
+using System.Reflection;
+using Xunit;
+
+namespace NotesApi.Tests.V1.Infrastructure
+{
+    public class FluentValidationExtensionsTests
+    {
+        [Fact]
+        public void AddFluentValidationTestNullServicesThrows()
+        {
+            IServiceCollection services = null;
+            Action act = () => FluentValidationExtensions.AddFluentValidation(services);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddFluentValidationTestNullAssembliesThrows()
+        {
+            var services = new ServiceCollection();
+            Action act = () => services.AddFluentValidation((Assembly[]) null);
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddFluentValidationTestEmptyAssembliesThrows()
+        {
+            var services = new ServiceCollection();
+            Action act = () => services.AddFluentValidation(Enumerable.Empty<Assembly>().ToArray());
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddFluentValidationTestAddsRequiredTypesFromExecutingAssembly()
+        {
+            var services = new ServiceCollection();
+            services.AddFluentValidation();
+
+            services.IsServiceRegistered<IValidatorInterceptor, UseErrorCodeInterceptor>().Should().BeTrue();
+        }
+
+        [Fact]
+        public void AddFluentValidationTestAddsRequiredTypesFromSuppliedAssemblies()
+        {
+            var services = new ServiceCollection();
+            services.AddFluentValidation(Assembly.GetAssembly(typeof(TestValidator)));
+
+            services.IsServiceRegistered<IValidatorInterceptor, UseErrorCodeInterceptor>().Should().BeTrue();
+
+            services.IsServiceImplementationRegistered<TestValidator>().Should().BeTrue();
+        }
+    }
+
+    public class TestEntity { }
+    public class TestValidator : AbstractValidator<TestEntity> { }
+
+    public static class ServiceCollectionExtensions
+    {
+        private static bool IsServiceRegistered<TServiceType>(ServiceDescriptor sd, string implementationTypeName) where TServiceType : class
+        {
+            if (null != sd.ImplementationInstance)
+            {
+                return sd.ServiceType == typeof(TServiceType)
+                    && sd.ImplementationInstance.GetType().Name == implementationTypeName;
+            }
+
+            return sd.ServiceType == typeof(TServiceType)
+                && sd.ImplementationType?.Name == implementationTypeName;
+        }
+
+        private static bool IsServiceImplementationRegistered<TImplementationType>(ServiceDescriptor sd) where TImplementationType : class
+        {
+            var implementationTypeName = typeof(TImplementationType).Name;
+            if (null != sd.ImplementationInstance)
+            {
+                return sd.ImplementationInstance.GetType().Name == implementationTypeName;
+            }
+
+            return sd.ImplementationType?.Name == implementationTypeName;
+        }
+
+        public static bool IsServiceRegistered<TServiceType>(this ServiceCollection services, string implementationTypeName) where TServiceType : class
+        {
+            return services.Any(x => IsServiceRegistered<TServiceType>(x, implementationTypeName));
+        }
+
+        public static bool IsServiceRegistered<TServiceType, TImplementationType>(this ServiceCollection services) where TServiceType : class where TImplementationType : class
+        {
+            return services.Any(x => IsServiceRegistered<TServiceType>(x, typeof(TImplementationType).Name));
+        }
+
+        public static bool IsServiceImplementationRegistered<TImplementationType>(this ServiceCollection services) where TImplementationType : class
+        {
+            return services.Any(x => IsServiceImplementationRegistered<TImplementationType>(x));
+        }
+    }
+}

--- a/NotesApi.Tests/V1/Infrastructure/UseErrorCodeInterceptorTests.cs
+++ b/NotesApi.Tests/V1/Infrastructure/UseErrorCodeInterceptorTests.cs
@@ -1,0 +1,99 @@
+using FluentAssertions;
+using FluentValidation;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using Moq;
+using NotesApi.V1.Infrastructure;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+using Xunit;
+
+namespace NotesApi.Tests.V1.Infrastructure
+{
+    public class UseErrorCodeInterceptorTests
+    {
+        private readonly JsonSerializerOptions _jsonOptions;
+        private readonly UseErrorCodeInterceptor _sut;
+        private readonly ActionContext _actionContext;
+        private readonly Mock<IValidationContext> _mockValidationContext;
+
+        public UseErrorCodeInterceptorTests()
+        {
+            _jsonOptions = CreateJsonOptions();
+            _sut = new UseErrorCodeInterceptor();
+
+            _actionContext = new ActionContext();
+            _mockValidationContext = new Mock<IValidationContext>();
+        }
+
+        private static JsonSerializerOptions CreateJsonOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            return options;
+        }
+
+        private IEnumerable<ValidationFailure> ConstructFailures()
+        {
+            var failures = new List<ValidationFailure>();
+            for (int i = 1; i < 5; i++)
+            {
+                failures.Add(new ValidationFailure($"prop-{i}", "Some error message")
+                {
+                    ErrorCode = i.ToString(),
+                    CustomState = "some custom state"
+                });
+            }
+            return failures;
+        }
+
+        [Fact]
+        public void BeforeAspNetValidationTestReturnContext()
+        {
+            _sut.BeforeAspNetValidation(_actionContext, _mockValidationContext.Object)
+                .Should().Be(_mockValidationContext.Object);
+        }
+
+        [Fact]
+        public void AfterAspNetValidationTestNoErrorsReturnsResult()
+        {
+            var validationResult = new ValidationResult();
+
+            _sut.AfterAspNetValidation(_actionContext, _mockValidationContext.Object, validationResult)
+                .Should().Be(validationResult);
+        }
+
+        [Fact]
+        public void AfterAspNetValidationTestReturnsProjectedResult()
+        {
+            var errors = ConstructFailures();
+            var validationResult = new ValidationResult(errors);
+
+            var projected = _sut.AfterAspNetValidation(_actionContext, _mockValidationContext.Object, validationResult);
+
+            foreach (var p in projected.Errors)
+            {
+                var src = errors.FirstOrDefault(x => x.PropertyName == p.PropertyName);
+                src.Should().NotBeNull();
+                p.Should().BeEquivalentTo(src, config => config.Excluding(x => x.ErrorMessage));
+
+                var expectedMsg = JsonSerializer.Serialize(new
+                {
+                    ErrorCode = src.ErrorCode,
+                    ErrorMessage = "Some error message",
+                    CustomState = src.CustomState
+                }, _jsonOptions);
+                p.ErrorMessage.Should().Be(expectedMsg);
+            }
+
+        }
+    }
+}

--- a/NotesApi/Startup.cs
+++ b/NotesApi/Startup.cs
@@ -1,7 +1,6 @@
 using Amazon;
 using Amazon.XRay.Recorder.Core;
 using Amazon.XRay.Recorder.Handlers.AwsSdk;
-using FluentValidation.AspNetCore;
 using Hackney.Core.DI;
 using Hackney.Core.DynamoDb;
 using Hackney.Core.DynamoDb.HealthCheck;
@@ -58,12 +57,14 @@ namespace NotesApi
 
             services
                 .AddMvc()
-                .AddFluentValidation(fv => fv.RegisterValidatorsFromAssembly(Assembly.GetExecutingAssembly()))
                 .AddJsonOptions(options =>
                 {
                     options.JsonSerializerOptions.Converters.Add(new JsonStringEnumConverter());
                 })
                 .SetCompatibilityVersion(CompatibilityVersion.Version_3_0);
+
+            services.AddFluentValidation();
+
             services.AddApiVersioning(o =>
             {
                 o.DefaultApiVersion = new ApiVersion(1, 0);

--- a/NotesApi/V1/Boundary/Request/Validation/AuthorDetailsValidator.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/AuthorDetailsValidator.cs
@@ -8,11 +8,18 @@ namespace NotesApi.V1.Boundary.Request.Validation
     {
         public AuthorDetailsValidator()
         {
-            RuleFor(x => x.Email).NotXssString()
-                                 .EmailAddress()
-                                 .When(x => !string.IsNullOrEmpty(x.Email));
+            RuleFor(x => x.Email)
+                .EmailAddress()
+                .WithErrorCode(ErrorCodes.InvalidEmail)
+                .When(x => !string.IsNullOrEmpty(x.Email));
+            RuleFor(x => x.Email)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(x => !string.IsNullOrEmpty(x.Email));
+
             RuleFor(x => x.FullName).NotXssString()
-                                    .When(x => !string.IsNullOrEmpty(x.FullName));
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(x => !string.IsNullOrEmpty(x.FullName));
         }
     }
 }

--- a/NotesApi/V1/Boundary/Request/Validation/CategorisationValidator.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/CategorisationValidator.cs
@@ -8,9 +8,20 @@ namespace NotesApi.V1.Boundary.Request.Validation
     {
         public CategorisationValidator()
         {
-            RuleFor(x => x.Category).NotXssString();
-            RuleFor(x => x.SubCategory).NotXssString();
-            RuleFor(x => x.Description).NotXssString();
+            RuleFor(x => x.Category)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(x => !string.IsNullOrEmpty(x.Category));
+
+            RuleFor(x => x.SubCategory)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(x => !string.IsNullOrEmpty(x.SubCategory));
+
+            RuleFor(x => x.Description)
+                .NotXssString()
+                .WithErrorCode(ErrorCodes.XssCheckFailure)
+                .When(x => !string.IsNullOrEmpty(x.Description));
         }
     }
 }

--- a/NotesApi/V1/Boundary/Request/Validation/CreateNoteRequestValidator.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/CreateNoteRequestValidator.cs
@@ -6,31 +6,29 @@ namespace NotesApi.V1.Boundary.Request.Validation
 {
     public class CreateNoteRequestValidator : AbstractValidator<CreateNoteRequest>
     {
-        //private const string RegExSpecialCharacters = @"(?i)^[a-z’'$£()/.,\s-]+$";
-
         public CreateNoteRequestValidator()
         {
             RuleFor(x => x.Description).NotNull()
                                        .NotEmpty()
-                                       .WithErrorCode("W2");
+                                       .WithErrorCode(ErrorCodes.DescriptionMandatory);
             RuleFor(x => x.Description).Length(1, 500)
-                                       .WithErrorCode("W3")
+                                       .WithErrorCode(ErrorCodes.DescriptionTooLong)
                                        .When(x => !string.IsNullOrEmpty(x.Description));
-            // TODO - Re-enable when the list of special charaters is finalised
-            //RuleFor(x => x.Description).Matches(x => RegExSpecialCharacters)
-            //                           .WithErrorCode("W8")
-            //                           .When(x => !string.IsNullOrEmpty(x.Description));
             RuleFor(x => x.Description).NotXssString()
+                                       .WithErrorCode(ErrorCodes.XssCheckFailure)
                                        .When(x => !string.IsNullOrEmpty(x.Description));
 
             RuleFor(x => x.TargetType).NotNull()
                                       .IsInEnum();
             RuleFor(x => x.TargetId).NotNull()
                                     .NotEqual(Guid.Empty);
+
             RuleFor(x => x.CreatedAt).NotNull()
                                      .NotEqual(default(DateTime));
 
             RuleFor(x => x.Author).SetValidator(new AuthorDetailsValidator());
+            RuleFor(x => x.Author).NotNull();
+
             RuleFor(x => x.Categorisation).SetValidator(new CategorisationValidator());
         }
     }

--- a/NotesApi/V1/Boundary/Request/Validation/CreateNoteRequestValidator.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/CreateNoteRequestValidator.cs
@@ -6,12 +6,23 @@ namespace NotesApi.V1.Boundary.Request.Validation
 {
     public class CreateNoteRequestValidator : AbstractValidator<CreateNoteRequest>
     {
+        //private const string RegExSpecialCharacters = @"(?i)^[a-z’'$£()/.,\s-]+$";
+
         public CreateNoteRequestValidator()
         {
             RuleFor(x => x.Description).NotNull()
                                        .NotEmpty()
-                                       .Length(1, 500)
-                                       .NotXssString();
+                                       .WithErrorCode("W2");
+            RuleFor(x => x.Description).Length(1, 500)
+                                       .WithErrorCode("W3")
+                                       .When(x => !string.IsNullOrEmpty(x.Description));
+            // TODO - Re-enable when the list of special charaters is finalised
+            //RuleFor(x => x.Description).Matches(x => RegExSpecialCharacters)
+            //                           .WithErrorCode("W8")
+            //                           .When(x => !string.IsNullOrEmpty(x.Description));
+            RuleFor(x => x.Description).NotXssString()
+                                       .When(x => !string.IsNullOrEmpty(x.Description));
+
             RuleFor(x => x.TargetType).NotNull()
                                       .IsInEnum();
             RuleFor(x => x.TargetId).NotNull()

--- a/NotesApi/V1/Boundary/Request/Validation/ErrorCodes.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/ErrorCodes.cs
@@ -4,7 +4,7 @@ namespace NotesApi.V1.Boundary.Request.Validation
     {
         public const string DescriptionMandatory = "W2";
         public const string DescriptionTooLong = "W3";
-        public const string InvalidEmail = "W100";
-        public const string XssCheckFailure = "W666";
+        public const string InvalidEmail = "W40";
+        public const string XssCheckFailure = "W42";
     }
 }

--- a/NotesApi/V1/Boundary/Request/Validation/ErrorCodes.cs
+++ b/NotesApi/V1/Boundary/Request/Validation/ErrorCodes.cs
@@ -1,0 +1,10 @@
+namespace NotesApi.V1.Boundary.Request.Validation
+{
+    public static class ErrorCodes
+    {
+        public const string DescriptionMandatory = "W2";
+        public const string DescriptionTooLong = "W3";
+        public const string InvalidEmail = "W100";
+        public const string XssCheckFailure = "W666";
+    }
+}

--- a/NotesApi/V1/Infrastructure/FluentValidationExtensions.cs
+++ b/NotesApi/V1/Infrastructure/FluentValidationExtensions.cs
@@ -1,0 +1,28 @@
+using FluentValidation.AspNetCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace NotesApi.V1.Infrastructure
+{
+    public static class FluentValidationExtensions
+    {
+        public static IServiceCollection AddFluentValidation(this IServiceCollection services)
+        {
+            return services.AddFluentValidation(Assembly.GetExecutingAssembly());
+        }
+
+        public static IServiceCollection AddFluentValidation(this IServiceCollection services, params Assembly[] assemblies)
+        {
+            if (services is null) throw new ArgumentNullException(nameof(services));
+            if (assemblies is null || !assemblies.Any()) throw new ArgumentNullException(nameof(assemblies));
+
+            services.AddFluentValidation(fv => fv.RegisterValidatorsFromAssemblies(assemblies));
+            services.TryAddTransient<IValidatorInterceptor, UseErrorCodeInterceptor>();
+
+            return services;
+        }
+    }
+}

--- a/NotesApi/V1/Infrastructure/UseErrorCodeInterceptor.cs
+++ b/NotesApi/V1/Infrastructure/UseErrorCodeInterceptor.cs
@@ -1,0 +1,65 @@
+using FluentValidation;
+using FluentValidation.AspNetCore;
+using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
+using System.Linq;
+using System.Text.Encodings.Web;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace NotesApi.V1.Infrastructure
+{
+    public class UseErrorCodeInterceptor : IValidatorInterceptor
+    {
+        private readonly JsonSerializerOptions _jsonOptions;
+
+        public UseErrorCodeInterceptor()
+        {
+            _jsonOptions = CreateJsonOptions();
+        }
+
+        private static JsonSerializerOptions CreateJsonOptions()
+        {
+            var options = new JsonSerializerOptions
+            {
+                PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+                WriteIndented = true,
+                Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
+            };
+            options.Converters.Add(new JsonStringEnumConverter());
+            return options;
+        }
+
+        private ValidationFailure ConstructFailure(ValidationFailure failure)
+        {
+            var errorDetail = new
+            {
+                ErrorCode = failure.ErrorCode,
+                ErrorMessage = failure.ErrorMessage,
+                CustomState = failure.CustomState
+            };
+            var errorDetailString = JsonSerializer.Serialize(errorDetail, _jsonOptions);
+            failure.ErrorMessage = errorDetailString;
+            return failure;
+        }
+
+        public IValidationContext BeforeAspNetValidation(ActionContext actionContext, IValidationContext commonContext)
+        {
+            return commonContext;
+        }
+
+        public ValidationResult AfterAspNetValidation(
+            ActionContext actionContext,
+            IValidationContext validationContext,
+            ValidationResult result)
+        {
+            if (result.Errors.Any())
+            {
+                var projection = result.Errors.Select(failure => ConstructFailure(failure));
+                return new ValidationResult(projection);
+            }
+
+            return result;
+        }
+    }
+}


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-1068

## Describe this PR

* Certain validation errors now include an error code
* Refactored FluentValidation setup on startup
* Implemented FluentValidation interceptor to ensure validation error codes get projected into the Http response.

#### _Checklist_

- [x] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [x] Added tests to cover all new production code
- [x] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [x] Checked all code for possible refactoring
- [x] Code pipeline builds correctly

