### PR TITLE
MTTL-2337: Create CloudWatch alarms

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -220,19 +220,16 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "development"
-          aws-account: $AWS_ACCOUNT_DEVELOPMENT
   deploy-to-staging:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
           stage: "staging"
-          aws-account: $AWS_ACCOUNT_STAGING
   deploy-to-production:
     executor: docker-dotnet
     steps:
       - deploy-lambda:
           stage: "production"
-          aws-account: $AWS_ACCOUNT_PRODUCTION
 workflows:
   check-and-deploy-development:
     jobs:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -107,8 +107,6 @@ commands:
     parameters:
       stage:
         type: string
-      aws-account:
-        type: string
     steps:
       - *attach_workspace
       - checkout
@@ -131,7 +129,7 @@ commands:
           name: Deploy lambda
           command: |
             cd ./NotesApi/
-            sls deploy --stage <<parameters.stage>> --account <<parameters.aws-account>> --conceal
+            sls deploy --stage <<parameters.stage>> --conceal
 
 jobs:
   check-code-formatting:

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -50,3 +50,16 @@ module "notes_api_cloudwatch_dashboard" {
   dynamodb_table_name = aws_dynamodb_table.notesapi_dynamodb_table.name
   include_sns_widget  = false
 }
+
+data "aws_ssm_parameter" "sns_topic_arn" {
+  name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"
+}
+
+module "api-alarm" {
+  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
+  environment_name = var.environment_name
+  api_name         = "notes-api"
+  alarm_period     = "300" #TODO: confirm this number
+  error_threshold  = "3" #TODO: confirm this number
+  sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
+}

--- a/terraform/development/main.tf
+++ b/terraform/development/main.tf
@@ -59,7 +59,7 @@ module "api-alarm" {
   source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
   environment_name = var.environment_name
   api_name         = "notes-api"
-  alarm_period     = "300" #TODO: confirm this number
-  error_threshold  = "3" #TODO: confirm this number
+  alarm_period     = "300"
+  error_threshold  = "1"
   sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
 }

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -51,3 +51,15 @@ module "notes_api_cloudwatch_dashboard" {
   include_sns_widget  = false
 }
 
+data "aws_ssm_parameter" "sns_topic_arn" {
+  name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"
+}
+
+module "api-alarm" {
+  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
+  environment_name = var.environment_name
+  api_name         = "notes-api"
+  alarm_period     = "300" #TODO: confirm this number
+  error_threshold  = "3" #TODO: confirm this number
+  sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
+}

--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -59,7 +59,7 @@ module "api-alarm" {
   source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
   environment_name = var.environment_name
   api_name         = "notes-api"
-  alarm_period     = "300" #TODO: confirm this number
-  error_threshold  = "3" #TODO: confirm this number
+  alarm_period     = "300"
+  error_threshold  = "1"
   sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
 }

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -50,3 +50,16 @@ module "notes_api_cloudwatch_dashboard" {
   dynamodb_table_name = aws_dynamodb_table.notesapi_dynamodb_table.name
   include_sns_widget  = false
 }
+
+data "aws_ssm_parameter" "sns_topic_arn" {
+  name = "/housing-tl/${var.environment_name}/cloudwatch-alarms-topic-arn"
+}
+
+module "api-alarm" {
+  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
+  environment_name = var.environment_name
+  api_name         = "notes-api"
+  alarm_period     = "300" #TODO: confirm this number
+  error_threshold  = "3" #TODO: confirm this number
+  sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
+}

--- a/terraform/staging/main.tf
+++ b/terraform/staging/main.tf
@@ -59,7 +59,7 @@ module "api-alarm" {
   source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/api-alarm"
   environment_name = var.environment_name
   api_name         = "notes-api"
-  alarm_period     = "300" #TODO: confirm this number
-  error_threshold  = "3" #TODO: confirm this number
+  alarm_period     = "300"
+  error_threshold  = "1"
   sns_topic_arn    = data.aws_ssm_parameter.sns_topic_arn.value
 }


### PR DESCRIPTION
## Link to JIRA ticket

https://hackney.atlassian.net/browse/MTTL-2337
https://hackney.atlassian.net/browse/MTTL-2362

## Describe this PR

- Implement CloudWatch alarms in all environments
- Fix deploy error with deprecated `--account` tag

#### _Checklist_

- [x] Code pipeline builds correctly

### *Follow up actions after merging PR*

[Configure the SNS topic correctly](https://docs.google.com/document/d/1Ym6exH_TbIN_-F-WT8TC10gZOKZ05Mzn35EQb65MMpk/edit?usp=sharing) in Staging & Prod before deployment and add the ARN value to parameter store