### PR TITLE
Update Hackney.Core.DynamoDb to newest version

### DIFF
--- a/NotesApi.Tests/V1/E2ETests/Steps/HealthCheckSteps.cs
+++ b/NotesApi.Tests/V1/E2ETests/Steps/HealthCheckSteps.cs
@@ -39,8 +39,8 @@ namespace NotesApi.Tests.V1.E2ETests.Steps
         {
             var apiResult = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
             apiResult.Status.Should().Be(HealthStatus.Healthy);
-            apiResult.Entries.First().Key.Should().Be("DynamoDb");
-            apiResult.Entries["DynamoDb"].Status.Should().Be(HealthStatus.Healthy);
+            apiResult.Entries.First().Key.Should().Be("DynamoDb_NoteDb");
+            apiResult.Entries["DynamoDb_NoteDb"].Status.Should().Be(HealthStatus.Healthy);
         }
     }
 }

--- a/NotesApi.Tests/V2/E2ETests/Steps/HealthCheckSteps.cs
+++ b/NotesApi.Tests/V2/E2ETests/Steps/HealthCheckSteps.cs
@@ -39,8 +39,8 @@ namespace NotesApi.Tests.V2.E2ETests.Steps
         {
             var apiResult = await ExtractResultFromHttpResponse(_lastResponse).ConfigureAwait(false);
             apiResult.Status.Should().Be(HealthStatus.Healthy);
-            apiResult.Entries.First().Key.Should().Be("DynamoDb");
-            apiResult.Entries["DynamoDb"].Status.Should().Be(HealthStatus.Healthy);
+            apiResult.Entries.First().Key.Should().Be("DynamoDb_NoteDb");
+            apiResult.Entries["DynamoDb_NoteDb"].Status.Should().Be(HealthStatus.Healthy);
         }
     }
 }

--- a/NotesApi/NotesApi.csproj
+++ b/NotesApi/NotesApi.csproj
@@ -13,11 +13,11 @@
 
   <ItemGroup>
     <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="7.2.0" />
-    <PackageReference Include="AWSXRayRecorder.Core" Version="2.11.1" />
+    <PackageReference Include="AWSXRayRecorder.Core" Version="2.13.0" />
     <PackageReference Include="AWSXRayRecorder.Handlers.AspNetCore" Version="2.8.1" />
-    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.9.1" />
+    <PackageReference Include="AWSXRayRecorder.Handlers.AwsSdk" Version="2.11.0" />
     <PackageReference Include="FluentValidation.AspNetCore" Version="10.3.3" />
-    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.77.0-feat-fix-enum0001" />
+    <PackageReference Include="Hackney.Core.DynamoDb" Version="1.84.0" />
     <PackageReference Include="Hackney.Core.HealthCheck" Version="1.49.0" />
     <PackageReference Include="Hackney.Core.Http" Version="1.63.0" />
     <PackageReference Include="Hackney.Core.JWT" Version="1.49.0" />


### PR DESCRIPTION
Upgrade API to use a non-preview version of Hackney.Core.DynamoDB. Since preview versions are experimental, they shouldn't be deployed past development.
