### PR TITLE
fix prod terraform

### DIFF
--- a/terraform/production/main.tf
+++ b/terraform/production/main.tf
@@ -80,11 +80,11 @@ resource "aws_ssm_parameter" "notes_sns_arn" {
   value = aws_sns_topic.notes.arn
 }  
     
-module "sns-delivery-failure-alarm" {
-  source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/sns-delivery-metric-and-alarm"
-  environment_name = var.environment_name
-  region           = data.aws_region.current.name
-  account_id       = data.aws_caller_identity.current.account_id
-  sns_topic_name   = "notes.fifo"
-  sns_topic_arn_for_notifications = data.aws_ssm_parameter.cloudwatch_topic_arn.value
-}
+# module "sns-delivery-failure-alarm" {
+#   source           = "github.com/LBHackney-IT/aws-hackney-common-terraform.git//modules/cloudwatch/sns-delivery-metric-and-alarm"
+#   environment_name = var.environment_name
+#   region           = data.aws_region.current.name
+#   account_id       = data.aws_caller_identity.current.account_id
+#   sns_topic_name   = "notes.fifo"
+#   sns_topic_arn_for_notifications = data.aws_ssm_parameter.cloudwatch_topic_arn.value
+# }


### PR DESCRIPTION
it has been a while since the pipeline has run in prod, hence the SNS topic needs to be reinstated again. 

After this PR the SNS alarm module will be active again hence this PR is just a temporary fix so the pipeline can pass - next PR will come shortly after. 