### PR TITLE
TsS-2045 add pre production workflows

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -229,134 +229,232 @@ jobs:
     steps:
       - deploy-lambda:
           stage: "production"
+  assume-role-pre-production:
+    executor: docker-python
+    steps:
+      - assume-role-and-persist-workspace:
+          aws-account: $AWS_ACCOUNT_PRE_PRODUCTION
+  terraform-init-and-plan-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-init-then-plan:
+          environment: "pre-production"
+  terraform-compliance-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-compliance:
+          environment: "pre-production"
+  terraform-apply-pre-production:
+    executor: docker-terraform
+    steps:
+      - terraform-apply:
+          environment: "pre-production"
+  deploy-to-pre-production:
+    executor: docker-dotnet
+    steps:
+      - deploy-lambda:
+          stage: "pre-production"
 
 workflows:
-  check-and-deploy-development:
+  # check-and-deploy-development:
+  #   jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #     - assume-role-development:
+  #         context: api-assume-role-housing-development-context
+  #         requires:
+  #           - build-and-test
+  #     - terraform-init-and-plan-development:
+  #         requires:
+  #           - assume-role-development
+  #     - terraform-compliance-development:
+  #         requires:
+  #           - terraform-init-and-plan-development
+  #     - terraform-apply-development:
+  #         requires:
+  #           - terraform-compliance-development
+  #         filters:
+  #           branches:
+  #             only: master
+  #     - deploy-to-development:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework" 
+  #         requires:
+  #           - terraform-apply-development
+  #         filters:
+  #           branches:
+  #             only: master
+  # check-and-deploy-staging-and-production:
+  #     jobs:
+  #     - check-code-formatting:
+  #         context: api-nuget-token-context
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - build-and-test:
+  #         context:
+  #           - api-nuget-token-context
+  #           - SonarCloud
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-staging:
+  #         context: api-assume-role-housing-staging-context
+  #         requires:
+  #             - build-and-test
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-staging:
+  #         requires:
+  #           - assume-role-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-staging:
+  #         requires:
+  #           - terraform-init-and-plan-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-staging:
+  #         requires:
+  #           - terraform-compliance-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-staging:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework" 
+  #         requires:
+  #           - terraform-apply-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-terraform-release:
+  #         type: approval
+  #         requires:
+  #           - deploy-to-staging
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - assume-role-production:
+  #         context: api-assume-role-housing-production-context
+  #         requires:
+  #             - permit-production-terraform-release
+  #         filters:
+  #            branches:
+  #              only: release
+  #     - terraform-init-and-plan-production:
+  #         requires:
+  #           - assume-role-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-compliance-production:
+  #         requires:
+  #           - terraform-init-and-plan-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - terraform-apply-production:
+  #         requires:
+  #           - terraform-compliance-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - permit-production-release:
+  #         type: approval
+  #         requires:
+  #           - terraform-apply-production
+  #         filters:
+  #           branches:
+  #             only: release
+  #     - deploy-to-production:
+  #         context:
+  #           - api-nuget-token-context
+  #           - "Serverless Framework"
+  #         requires:
+  #           - permit-production-release
+  #         filters:
+  #           branches:
+  #             only: release
+
+  deploy-terraform-pre-production:
     jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
+      - permit-pre-production-terraform-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
+          requires:
+            - permit-pre-production-terraform-workflow
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-init-and-plan-pre-production:
+          requires:
+            - assume-role-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-compliance-pre-production:
+          requires:
+            - terraform-init-and-plan-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - permit-pre-production-terraform-deployment:
+          type: approval
+          requires:
+            - terraform-compliance-pre-production
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - terraform-apply-pre-production:
+          requires:
+            - permit-pre-production-terraform-deployment
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+
+  deploy-code-pre-production:
+    jobs:
+      - permit-pre-production-code-workflow:
+          type: approval
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          context:
+          requires:
+            - permit-pre-production-code-workflow
+          context: 
             - api-nuget-token-context
             - SonarCloud
-      - assume-role-development:
-          context: api-assume-role-housing-development-context
+          filters:
+            branches:
+              only: ts-2045-add-pre-production-workflows
+      - assume-role-pre-production:
+          context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
-      - terraform-init-and-plan-development:
-          requires:
-            - assume-role-development
-      - terraform-compliance-development:
-          requires:
-            - terraform-init-and-plan-development
-      - terraform-apply-development:
-          requires:
-            - terraform-compliance-development
           filters:
             branches:
-              only: master
-      - deploy-to-development:
+              only: ts-2045-add-pre-production-workflows
+      - deploy-to-pre-production:
           context:
-            - api-nuget-token-context
-            - "Serverless Framework" 
+          - api-nuget-token-context
+          - "Serverless Framework"
           requires:
-            - terraform-apply-development
+            - assume-role-pre-production        
           filters:
             branches:
-              only: master
-  check-and-deploy-staging-and-production:
-      jobs:
-      - check-code-formatting:
-          context: api-nuget-token-context
-          filters:
-            branches:
-              only: release
-      - build-and-test:
-          context:
-            - api-nuget-token-context
-            - SonarCloud
-          filters:
-            branches:
-              only: release
-      - assume-role-staging:
-          context: api-assume-role-housing-staging-context
-          requires:
-              - build-and-test
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-staging:
-          requires:
-            - assume-role-staging
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-staging:
-          requires:
-            - terraform-init-and-plan-staging
-          filters:
-            branches:
-              only: release
-      - terraform-apply-staging:
-          requires:
-            - terraform-compliance-staging
-          filters:
-            branches:
-              only: release
-      - deploy-to-staging:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework" 
-          requires:
-            - terraform-apply-staging
-          filters:
-            branches:
-              only: release
-      - permit-production-terraform-release:
-          type: approval
-          requires:
-            - deploy-to-staging
-          filters:
-            branches:
-              only: release
-      - assume-role-production:
-          context: api-assume-role-housing-production-context
-          requires:
-              - permit-production-terraform-release
-          filters:
-             branches:
-               only: release
-      - terraform-init-and-plan-production:
-          requires:
-            - assume-role-production
-          filters:
-            branches:
-              only: release
-      - terraform-compliance-production:
-          requires:
-            - terraform-init-and-plan-production
-          filters:
-            branches:
-              only: release
-      - terraform-apply-production:
-          requires:
-            - terraform-compliance-production
-          filters:
-            branches:
-              only: release
-      - permit-production-release:
-          type: approval
-          requires:
-            - terraform-apply-production
-          filters:
-            branches:
-              only: release
-      - deploy-to-production:
-          context:
-            - api-nuget-token-context
-            - "Serverless Framework"
-          requires:
-            - permit-production-release
-          filters:
-            branches:
-              only: release
+              only: ts-2045-add-pre-production-workflows

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -256,135 +256,135 @@ jobs:
           stage: "pre-production"
 
 workflows:
-  # check-and-deploy-development:
-  #   jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #     - assume-role-development:
-  #         context: api-assume-role-housing-development-context
-  #         requires:
-  #           - build-and-test
-  #     - terraform-init-and-plan-development:
-  #         requires:
-  #           - assume-role-development
-  #     - terraform-compliance-development:
-  #         requires:
-  #           - terraform-init-and-plan-development
-  #     - terraform-apply-development:
-  #         requires:
-  #           - terraform-compliance-development
-  #         filters:
-  #           branches:
-  #             only: master
-  #     - deploy-to-development:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework" 
-  #         requires:
-  #           - terraform-apply-development
-  #         filters:
-  #           branches:
-  #             only: master
-  # check-and-deploy-staging-and-production:
-  #     jobs:
-  #     - check-code-formatting:
-  #         context: api-nuget-token-context
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - build-and-test:
-  #         context:
-  #           - api-nuget-token-context
-  #           - SonarCloud
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-staging:
-  #         context: api-assume-role-housing-staging-context
-  #         requires:
-  #             - build-and-test
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-staging:
-  #         requires:
-  #           - assume-role-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-staging:
-  #         requires:
-  #           - terraform-init-and-plan-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-staging:
-  #         requires:
-  #           - terraform-compliance-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-staging:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework" 
-  #         requires:
-  #           - terraform-apply-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-terraform-release:
-  #         type: approval
-  #         requires:
-  #           - deploy-to-staging
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - assume-role-production:
-  #         context: api-assume-role-housing-production-context
-  #         requires:
-  #             - permit-production-terraform-release
-  #         filters:
-  #            branches:
-  #              only: release
-  #     - terraform-init-and-plan-production:
-  #         requires:
-  #           - assume-role-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-compliance-production:
-  #         requires:
-  #           - terraform-init-and-plan-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - terraform-apply-production:
-  #         requires:
-  #           - terraform-compliance-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - permit-production-release:
-  #         type: approval
-  #         requires:
-  #           - terraform-apply-production
-  #         filters:
-  #           branches:
-  #             only: release
-  #     - deploy-to-production:
-  #         context:
-  #           - api-nuget-token-context
-  #           - "Serverless Framework"
-  #         requires:
-  #           - permit-production-release
-  #         filters:
-  #           branches:
-  #             only: release
+  check-and-deploy-development:
+    jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+      - assume-role-development:
+          context: api-assume-role-housing-development-context
+          requires:
+            - build-and-test
+      - terraform-init-and-plan-development:
+          requires:
+            - assume-role-development
+      - terraform-compliance-development:
+          requires:
+            - terraform-init-and-plan-development
+      - terraform-apply-development:
+          requires:
+            - terraform-compliance-development
+          filters:
+            branches:
+              only: master
+      - deploy-to-development:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework" 
+          requires:
+            - terraform-apply-development
+          filters:
+            branches:
+              only: master
+  check-and-deploy-staging-and-production:
+      jobs:
+      - check-code-formatting:
+          context: api-nuget-token-context
+          filters:
+            branches:
+              only: release
+      - build-and-test:
+          context:
+            - api-nuget-token-context
+            - SonarCloud
+          filters:
+            branches:
+              only: release
+      - assume-role-staging:
+          context: api-assume-role-housing-staging-context
+          requires:
+              - build-and-test
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-staging:
+          requires:
+            - assume-role-staging
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-staging:
+          requires:
+            - terraform-init-and-plan-staging
+          filters:
+            branches:
+              only: release
+      - terraform-apply-staging:
+          requires:
+            - terraform-compliance-staging
+          filters:
+            branches:
+              only: release
+      - deploy-to-staging:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework" 
+          requires:
+            - terraform-apply-staging
+          filters:
+            branches:
+              only: release
+      - permit-production-terraform-release:
+          type: approval
+          requires:
+            - deploy-to-staging
+          filters:
+            branches:
+              only: release
+      - assume-role-production:
+          context: api-assume-role-housing-production-context
+          requires:
+              - permit-production-terraform-release
+          filters:
+             branches:
+               only: release
+      - terraform-init-and-plan-production:
+          requires:
+            - assume-role-production
+          filters:
+            branches:
+              only: release
+      - terraform-compliance-production:
+          requires:
+            - terraform-init-and-plan-production
+          filters:
+            branches:
+              only: release
+      - terraform-apply-production:
+          requires:
+            - terraform-compliance-production
+          filters:
+            branches:
+              only: release
+      - permit-production-release:
+          type: approval
+          requires:
+            - terraform-apply-production
+          filters:
+            branches:
+              only: release
+      - deploy-to-production:
+          context:
+            - api-nuget-token-context
+            - "Serverless Framework"
+          requires:
+            - permit-production-release
+          filters:
+            branches:
+              only: release
 
   deploy-terraform-pre-production:
     jobs:
@@ -392,63 +392,56 @@ workflows:
           type: approval
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - permit-pre-production-terraform-workflow
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-init-and-plan-pre-production:
           requires:
             - assume-role-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-compliance-pre-production:
           requires:
             - terraform-init-and-plan-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - permit-pre-production-terraform-deployment:
           type: approval
           requires:
             - terraform-compliance-pre-production
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - terraform-apply-pre-production:
           requires:
             - permit-pre-production-terraform-deployment
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
 
   deploy-code-pre-production:
     jobs:
-      - permit-pre-production-code-workflow:
-          type: approval
-          filters:
-            branches:
-              only: ts-2045-add-pre-production-workflows
       - build-and-test:
-          requires:
-            - permit-pre-production-code-workflow
           context: 
             - api-nuget-token-context
             - SonarCloud
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - assume-role-pre-production:
           context: api-assume-role-housing-pre-production-context
           requires:
             - build-and-test
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release
       - deploy-to-pre-production:
           context:
           - api-nuget-token-context
@@ -457,4 +450,4 @@ workflows:
             - assume-role-pre-production        
           filters:
             branches:
-              only: ts-2045-add-pre-production-workflows
+              only: release

--- a/NotesApi/serverless.yml
+++ b/NotesApi/serverless.yml
@@ -132,15 +132,6 @@ resources:
                           - Ref: 'AWS::Region'
                           - Ref: 'AWS::AccountId'
                           - 'log-group:/aws/lambda/*:*:*'
-                - Effect: "Allow"
-                  Action:
-                    - "s3:PutObject"
-                    - "s3:GetObject"
-                  Resource:
-                    Fn::Join:
-                      - ""
-                      - - "arn:aws:s3:::"
-                        - "Ref": "ServerlessDeploymentBucket"
           - PolicyName: lambdaInvocation
             PolicyDocument:
               Version: '2012-10-17'
@@ -154,6 +145,7 @@ custom:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-auth-verify-token-new-development-apiauthverifytokennew
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-auth-verify-token-new-staging-apiauthverifytokennew
     production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer
       safeguard: require-authorizer
@@ -184,3 +176,9 @@ custom:
       subnetIds:
         - subnet-06a697d86a9b6ed01
         - subnet-0beb266003a56ca82
+    pre-production:
+      securityGroupIds:
+        - Ref: LambdaSecurityGroup
+      subnetIds:
+        - subnet-08aa35159a8706faa
+        - subnet-0b848c5b14f841dfb

--- a/NotesApi/serverless.yml
+++ b/NotesApi/serverless.yml
@@ -157,6 +157,7 @@ custom:
     development: vpc-0d15f152935c8716f
     staging: vpc-064521a7a4109ba31
     production: vpc-0ce853ddb64e8fb3c
+    pre-production: vpc-062a957b99c8b12e6
   vpc:
     development:
       securityGroupIds:

--- a/terraform/pre-production/aws_ssm_parameter.tf
+++ b/terraform/pre-production/aws_ssm_parameter.tf
@@ -1,0 +1,11 @@
+resource "aws_ssm_parameter" "aspnetcore_environment" {
+  name  = "/housing-tl/pre-production/aspnetcore-environment"
+  type  = "String"
+  value = "to_be_set_manually"
+
+  lifecycle {
+    ignore_changes = [
+      value,
+    ]
+  }
+}

--- a/terraform/pre-production/dynamodb.tf
+++ b/terraform/pre-production/dynamodb.tf
@@ -1,0 +1,38 @@
+resource "aws_dynamodb_table" "notesapi_dynamodb_table" {
+  name           = "Notes"
+  billing_mode   = "PROVISIONED"
+  read_capacity  = 10
+  write_capacity = 10
+  hash_key       = "targetId"
+  range_key      = "id"
+
+  attribute {
+    name = "id"
+    type = "S"
+  }
+
+  attribute {
+    name = "targetId"
+    type = "S"
+  }
+
+  attribute {
+    name = "createdAt"
+    type = "S"
+  }
+
+  local_secondary_index {
+    name            = "NotesByCreated"
+    range_key       = "createdAt"
+    projection_type = "ALL"
+  }
+
+  tags = merge(
+    local.default_tags,
+    { BackupPolicy = "Dev", Backup = false, Confidentiality = "Internal" }
+  )
+
+  point_in_time_recovery {
+    enabled = false
+  }
+}

--- a/terraform/pre-production/maint.tf
+++ b/terraform/pre-production/maint.tf
@@ -1,0 +1,46 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 3.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = "eu-west-2"
+}
+
+locals {
+  default_tags = {
+    Name              = "notes-api-${var.environment_name}"
+    Environment       = var.environment_name
+    terraform-managed = true
+    project_name      = var.project_name
+    Application       = "MTFH Housing Pre-Production"
+    TeamEmail         = "developementteam@hackney.gov.uk"
+  }
+}
+
+terraform {
+  backend "s3" {
+    bucket         = "housing-pre-production-terraform-state"
+    encrypt        = true
+    region         = "eu-west-2"
+    key            = "services/notes-api/state"
+    dynamodb_table = "housing-pre-production-terraform-state-lock"
+  }
+}
+
+resource "aws_sns_topic" "notes" {
+  name                        = "notes.fifo"
+  fifo_topic                  = true
+  content_based_deduplication = true
+  kms_master_key_id           = "alias/aws/sns"
+}
+
+resource "aws_ssm_parameter" "notes_sns_arn" {
+  name  = "/sns-topic/pre-production/notes/arn"
+  type  = "String"
+  value = aws_sns_topic.notes.arn
+}

--- a/terraform/pre-production/terraform-compliance/dynamodb.feature
+++ b/terraform/pre-production/terraform-compliance/dynamodb.feature
@@ -1,0 +1,26 @@
+Feature: DynamoDB is used as our NoSQL database service
+  In order to improve security
+  As engineers
+  We'll use ensure our DynamoDB tables are configured correctly
+
+  Scenario: Ensure BackupPolicy tag is present
+    Given I have aws_dynamodb_table defined
+    Then it must contain tags
+    And it must contain BackupPolicy
+
+  Scenario: Ensure point in time recovery disabled
+    Given I have aws_dynamodb_table defined
+    Then it must contain point_in_time_recovery
+    And its enabled property must be false
+
+  Scenario: Ensure a maximum of 1 LSIs
+    Given I have aws_dynamodb_table defined
+    When it contains local_secondary_index
+    When I count them
+    Then I expect the result is less and equal to 1
+
+  Scenario: Ensure a maximum of 2 GSIs
+    Given I have aws_dynamodb_table defined
+    When it contains global_secondary_index
+    When I count them
+    Then I expect the result is less and equal to 2

--- a/terraform/pre-production/terraform-compliance/sns.feature
+++ b/terraform/pre-production/terraform-compliance/sns.feature
@@ -1,0 +1,8 @@
+Feature: SNS is used as our notification service
+  In order to improve security
+  As engineers
+  We'll use ensure our SNS topics are configured correctly
+
+  Scenario: Ensure encryption is enabled
+    Given I have aws_sns_topic defined
+    Then it must contain kms_master_key_id

--- a/terraform/pre-production/variables.tf
+++ b/terraform/pre-production/variables.tf
@@ -1,0 +1,9 @@
+variable "environment_name" {
+  type    = string
+  default = "pre-prod"
+}
+
+variable "project_name" {
+  type    = string
+  default = "Housing-Pre-Production"
+}


### PR DESCRIPTION
## Link to JIRA ticket

[TS-2045](https://hackney.atlassian.net/browse/TS-2045)

## Describe this PR

### *What is the problem we're trying to solve*

We need to deploy this API to new housing-pre-production account in order to complete the MTFH/TA backend setup in that environment.

### *What changes have we introduced*

1. Add Terraform resources for pre-production. This includes parameter store value dependencies on top of the existing, production based, configuration
2. Add Terraform and code deployment workflows for pre-production. Terraform workflow requires manual approval to run but the code workflow runs automatically. This ensure pre-production is always in line with production
3. Remove the unnecessary policy that's stopping deployments from working when using Serverless V4 against new accounts. The policy is not required for the Lambda.

#### _Checklist_

- [ ] Added end-to-end (i.e. integration) tests where necessary e.g to test complete functionality of a newly added feature
- [ ] Added tests to cover all new production code
- [ ] Added comments to the README or updated relevant documentation _(add link to documentation)_, where necessary.
- [ ] Checked all code for possible refactoring
- [ ] Code pipeline builds correctly



[TS-2045]: https://hackney.atlassian.net/browse/TS-2045?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ