### PR TITLE
Switch lambda's `production` authorizer to new Cognito authorizer.

### DIFF
--- a/NotesApi/serverless.yml
+++ b/NotesApi/serverless.yml
@@ -144,7 +144,7 @@ custom:
   authorizerArns:
     development: arn:aws:lambda:eu-west-2:859159924354:function:api-gateway-lambda-authorizer
     staging:     arn:aws:lambda:eu-west-2:715003523189:function:api-gateway-lambda-authorizer
-    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-auth-verify-token-new-production-apiauthverifytokennew
+    production:  arn:aws:lambda:eu-west-2:153306643385:function:api-gateway-lambda-authorizer
     pre-production: arn:aws:lambda:eu-west-2:578479666894:function:api-auth-verify-token-new-pre-production-apiauthverifytokennew
   safeguards:
     - title: Require authorizer


### PR DESCRIPTION
# What:
 - Switch the old legacy lambda authorizer to the new Cognito-supporting one.

# Why:
 - Part of the work of rolling out AWS Cognito authentication flow to `production`.

# Notes:
 - Leaving the `pre-production` environment as is as its fate is up in the air with no signs of work on it getting continued any time soon.